### PR TITLE
chore(pipeline): fix pipeline commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "start": "node index.js",
     "lint:deps": "npx updated",
     "lint:ec": "npx editorconfig-checker .",
-    "lint:js": "npx eslint .",
+    "lint:js": "eslint .",
     "lint:md": "npx remark-cli --quiet --frail .",
     "lint": "npx npm-run-all -p lint:*",
     "release:dryrun": "npx semantic-release --dry-run --branch $(git describe --contains --all HEAD)",


### PR DESCRIPTION
When using `npx eslint .` leads to issues on github actions because it does not find global eslint packages